### PR TITLE
Upgrade vertx-core to 3.9.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
-      <version>3.5.4</version>
+      <version>3.9.8</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Hi

Package Owner: Abhishek kumar nishant

PR change Details:
$Patch Details : Following file has been modified:

.pom.xml:
Modified pom.xml to update vertx-core version from '3.5.4' to '3.9.8'.

$Testing Detail:

After doing the changes,verified working by executing 'mvn install' command and all test cases are running fine on x86 and aarch64 both platforms

$PR Description :Here is my commit message :

Upgrade vertx-core to 3.9.8

Body

vertx-core depends on netty so updated vertx-core to update netty here

Signed-off-by: odidev odidev@puresoftware.com

$ Reviewer: Shobhit Parashri